### PR TITLE
Replacing generic exception with more informative, actual exception.

### DIFF
--- a/recipes/omniauth.rb
+++ b/recipes/omniauth.rb
@@ -46,21 +46,17 @@ RUBY
     inject_into_file 'app/models/user.rb', :before => 'end' do <<-RUBY
 
   def self.create_with_omniauth(auth)
-    begin
-      create! do |user|
-        user.provider = auth['provider']
-        user.uid = auth['uid']
-        if auth['user_info']
-          user.name = auth['user_info']['name'] if auth['user_info']['name'] # Twitter, Google, Yahoo, GitHub
-          user.email = auth['user_info']['email'] if auth['user_info']['email'] # Google, Yahoo, GitHub
-        end
-        if auth['extra']['user_hash']
-          user.name = auth['extra']['user_hash']['name'] if auth['extra']['user_hash']['name'] # Facebook
-          user.email = auth['extra']['user_hash']['email'] if auth['extra']['user_hash']['email'] # Facebook
-        end
+    create! do |user|
+      user.provider = auth['provider']
+      user.uid = auth['uid']
+      if auth['user_info']
+        user.name = auth['user_info']['name'] if auth['user_info']['name'] # Twitter, Google, Yahoo, GitHub
+        user.email = auth['user_info']['email'] if auth['user_info']['email'] # Google, Yahoo, GitHub
       end
-    rescue Exception
-      raise Exception, "cannot create user record"
+      if auth['extra']['user_hash']
+        user.name = auth['extra']['user_hash']['name'] if auth['extra']['user_hash']['name'] # Facebook
+        user.email = auth['extra']['user_hash']['email'] if auth['extra']['user_hash']['email'] # Facebook
+      end
     end
   end
 


### PR DESCRIPTION
This may be a matter of opinion, but I don't see the point in rescuing from _any_ exception only to raise a generic, less informative exception.  Rescuing and then _not_ raising another exception I could understand.
