### PR TITLE
Use SASS gem

### DIFF
--- a/recipes/sass.rb
+++ b/recipes/sass.rb
@@ -1,13 +1,11 @@
-unless recipes.include? 'haml'
-  gem 'haml', '>= 3.0.0'
-end
+gem 'sass', '>= 3.1.6'
 
 __END__
 
 name: SASS
-description: "Utilize SASS (through the HAML gem) for really awesome stylesheets!"
-author: mbleigh
+description: "Utilize SASS for really awesome stylesheets!"
+author: mbleigh & mrc2407
 
-exclusive: css_replacement 
+exclusive: css_replacement
 category: assets
 tags: [css]


### PR DESCRIPTION
The SASS recipe was including HAML instead of the real SASS gem. This is not a really intuitive behaviour and it might get people confused if they wanted to use slim instead of haml, because if they wanted to use slim and SASS they would see both slim and haml gems installed... 
