### PR TITLE
HTML5 Boilerplate recipe's javascript URLs were outdated

### DIFF
--- a/recipes/html5.rb
+++ b/recipes/html5.rb
@@ -6,8 +6,7 @@ if config['html5']
     after_bundler do
       say_wizard "HTML5 Boilerplate recipe running 'after bundler'"
       # Download HTML5 Boilerplate JavaScripts
-      get "https://raw.github.com/paulirish/html5-boilerplate/master/js/libs/modernizr-2.0.min.js", "app/assets/javascripts/modernizr.js"
-      get "https://raw.github.com/paulirish/html5-boilerplate/master/js/libs/respond.min.js", "app/assets/javascripts/respond.js"
+      get "https://raw.github.com/paulirish/html5-boilerplate/master/js/libs/modernizr-2.0.6.min.js", "app/assets/javascripts/modernizr.js"
       # Download stylesheet to normalize or reset CSS
       case config['css_option']
         when 'skeleton'


### PR DESCRIPTION
Hi,

When generating a new rails app that includes the HTML5 boilerplate code, I received an ``open_http': 404 Not Found (OpenURI::HTTPError)` error. On further investigation, it seems that a few days ago the html5 boilerplate code has changed the modernizr version from 2.0 to 2.0.6 and also merged respond.js into that file, so these two files could not be downloaded by the html5 recipe (see paulirish/html5-boilerplate@e49793fd).

Attached is a fix for this problem (essentially just updated the urls).

Thanks,
Zaki
