### PR TITLE
Update the Compass recipe

### DIFF
--- a/recipes/compass.rb
+++ b/recipes/compass.rb
@@ -1,5 +1,5 @@
 if config['compass']
-  gem 'compass', :version => '~> 0.12', :group => [:assets]
+  gem 'compass', :version => '~> 0.12.1', :group => [:assets]
   gem 'compass-rails', :version => '~> 1.0.0', :group => [:assets]
   after_bundler do
     remove_file 'app/assets/stylesheets/application.css'


### PR DESCRIPTION
Hello,

I've updated the Compass recipe to:
- Use the final 0.12.x release (not the prerelease), and
- Use `compass-rails`, as Rails integration is now no longer part of 0.12.x
