### PR TITLE
Make run_after work again

### DIFF
--- a/lib/rails_wizard/template.rb
+++ b/lib/rails_wizard/template.rb
@@ -18,8 +18,7 @@ module RailsWizard
 
 
     def resolve_recipes
-      # @resolve_recipes ||= recipes_with_dependencies.sort
-      @resolve_recipes ||= recipes_with_dependencies
+      @resolve_recipes ||= recipes_with_dependencies.sort
     end
 
     def recipe_classes

--- a/recipes/add_user.rb
+++ b/recipes/add_user.rb
@@ -96,5 +96,6 @@ name: AddUser
 description: "Add a User model including 'name' and 'email' attributes."
 author: RailsApps
 
+run_after: [devise, omniauth]
 category: other
 tags: [utilities, configuration]


### PR DESCRIPTION
The `run_after` directive was decomissioned 11 months ago because (I assume from reading the recipe updates before it) it was no longer needed by recipes at that time.

However, there are new instances where the order of recipes matters. For instance, the `devise.rb` recipe does `generate 'devise:install'`, while the `add_user.rb` recipe calls `generate 'devise user'`. If the latter is called first, it will cause an error.

This patch reverts 478a94fb. Relevant comment: https://github.com/RailsApps/rails_apps_composer/commit/478a94fb1caad90b82f43c06ad3cb3ed8de07900#commitcomment-1084534
