### PR TITLE
Run rails_footnotes generator if enabled

### DIFF
--- a/recipes/extras.rb
+++ b/recipes/extras.rb
@@ -4,6 +4,9 @@
 if config['footnotes']
   say_wizard "Extras recipe running 'after bundler'"
   gem 'rails-footnotes', '>= 3.7', :group => :development
+  after_bundler do
+    generate 'rails_footnotes:install'
+  end
 else
   recipes.delete('footnotes')
 end


### PR DESCRIPTION
Since we've already warned that rails_footnotes is slow, enable it by running the generator.
