### PR TITLE
Gemfile error when using Cucumber and Capybara recipes together

### DIFF
--- a/recipes/capybara.rb
+++ b/recipes/capybara.rb
@@ -1,4 +1,4 @@
-gem 'capybara', :group => [:development, :test] unless config['cucumber']
+gem 'capybara', :group => [:development, :test] unless recipes.include? 'cucumber'
 
 after_bundler do
   create_file "spec/support/capybara.rb", <<-RUBY


### PR DESCRIPTION
Hi there!

Thanks for the very useful gem! I was getting the following when trying to install a new app with the Capybara _and_ Cucumber recipes. 

```
rails_apps_composer new test -r capybara cucumber
...
    cucumber  Would you like to use Cucumber for your BDD? (y/n) y
     gemfile    cucumber-rails (>= 1.3.0)
     gemfile    capybara (>= 1.1.2)
     gemfile    database_cleaner (>= 0.7.2)
     gemfile    launchy (>= 2.1.0)
      wizard  Running 'bundle install'. This will take a while.
         run    bundle install from "."
You cannot specify the same gem twice with different version requirements. You specified: capybara (>= 0) and capybara (>= 1.1.2)
```

There is a very simple workaround (not using the Capybara and Cucumber recipes together, and just use Cucumber), but with a little digging I think I have found the problem. 

It seems that the capybara recipe was always adding its gem into the Gemfile because the existing check for the cucumber recipe `config['cucumber']` was always resolving to false. 

I'm not entirely sure what `config[]` is, but judging from the rest of the project, it seems `recipes` should be being checked against instead, so I have changed it to use `recipes.include?`.

Apologies if the `config['cucumber']` check is doing something I am not aware of!

Thanks!
