### PR TITLE
set up routes for rails_admin with the recipe...e.g. mount engine at /ad...

### DIFF
--- a/recipes/rails_admin.rb
+++ b/recipes/rails_admin.rb
@@ -6,6 +6,14 @@ after_bundler do
   rake 'admin:ckeditor_download' if config['ckeditor']
 end
 
+inject_into_file 'config/routes.rb', :after => "routes.draw do" do 
+<<-RUBY
+\n
+  mount RailsAdmin::Engine => '/admin', :as => 'rails_admin'
+\n  
+RUBY
+end
+
 __END__
 
 name: RailsAdmin


### PR DESCRIPTION
I figure the recipe may as well mount the engine if it's installing it for the app. Wonder if this sort of addition would be good in other recipes? (devise?)
