### PR TITLE
[guard] Fix duplicate configuration on Guardfile

### DIFF
--- a/recipes/guard.rb
+++ b/recipes/guard.rb
@@ -50,9 +50,7 @@ end
 
   guard 'bundler', '>= 0.1.3'
 
-  unless recipes.include? 'pow'
-    guard 'rails', '>= 0.0.3'
-  end
+  guard 'rails', '>= 0.0.3'
   
   if recipes.include? 'guard-LiveReload'
     guard 'livereload', '>= 0.3.0'


### PR DESCRIPTION
A single call of `guard init` initializes configuration for all guards.
The recipe was initializing every one again causing duplication.

Also remove check for the pow recipe that doesn't exist anymore.
