### PR TITLE
[rspec] Downgrade mongoid-rspec version

### DIFF
--- a/recipes/rspec.rb
+++ b/recipes/rspec.rb
@@ -6,8 +6,8 @@ if config['rspec']
   if recipes.include? 'mongoid'
     # use the database_cleaner gem to reset the test database
     gem 'database_cleaner', '>= 0.8.0', :group => :test
-    # include RSpec matchers from the mongoid-rspec gem
-    gem 'mongoid-rspec', '>= 1.4.6', :group => :test
+    # include RSpec matchers from the mongoid-rspec gem, 1.4.6 requires mongoid 3.0.0.rc making it impossible to resolve dependencies
+    gem 'mongoid-rspec', '1.4.5', :group => :test
   end
   if config['machinist']
     gem 'machinist', :group => :test


### PR DESCRIPTION
Downgrade `mongoid-rspec` version to avoid conflict of mongoid version
with the one required by `will_paginate_mongoid` (from extras recipe).

This is what happens when you have the extras, mongoid and rspec recipes:

```
Bundler could not find compatible versions for gem "mongoid":
  In Gemfile:
    will_paginate_mongoid (>= 0) ruby depends on
      mongoid (~> 2.2.2) ruby

    mongoid-rspec (>= 1.4.6) ruby depends on
      mongoid (3.0.0.rc)
```
