### PR TITLE
HTML5 - Remove tabs.js from Skeleton setup

### DIFF
--- a/recipes/html5.rb
+++ b/recipes/html5.rb
@@ -124,7 +124,6 @@ RUBY
       get 'https://raw.github.com/dhgamache/Skeleton/master/stylesheets/base.css', 'app/assets/stylesheets/base.css.scss'
       get 'https://raw.github.com/dhgamache/Skeleton/master/stylesheets/layout.css', 'app/assets/stylesheets/layout.css.scss'
       get 'https://raw.github.com/dhgamache/Skeleton/master/stylesheets/skeleton.css', 'app/assets/stylesheets/skeleton.css.scss'
-      get 'https://raw.github.com/dhgamache/Skeleton/master/javascripts/tabs.js', 'app/assets/javascripts/tabs.js'
 
     when 'normalize'
       say_wizard 'normalizing CSS for consistent styling'


### PR DESCRIPTION
The tabs.js file is no longer included in Skeleton. This commit removes it from the HTML5 recipe.

The commit removing tabs.js from Skeleton.
https://github.com/dhgamache/Skeleton/commit/1fb5487ce31bdeb2cb43d20ecc96e9f815b10d6d
