### PR TITLE
Specifying an unknown recipe bombs out with a stacktrace.

### DIFF
--- a/lib/rails_wizard/command.rb
+++ b/lib/rails_wizard/command.rb
@@ -98,18 +98,22 @@ module RailsWizard
         else
           file = Tempfile.new('template')
         end
-        template = RailsWizard::Template.new(recipes, defaults)
-        file.write template.compile
-        file.close
-        if name
-          system "rails new #{name} -m #{file.path} #{template.args.join(' ')}"
-        else
-          puts "install with the command:"
-          puts
-          puts "rails new <APP_NAME> -m #{file.path} #{template.args.join(' ')}"
+        begin
+          template = RailsWizard::Template.new(recipes, defaults)
+          file.write template.compile
+          file.close
+          if name
+            system "rails new #{name} -m #{file.path} #{template.args.join(' ')}"
+          else
+            puts "install with the command:"
+            puts
+            puts "rails new <APP_NAME> -m #{file.path} #{template.args.join(' ')}"
+          end
+        rescue RailsWizard::UnknownRecipeError
+          raise Thor::Error.new("> #{red}#{$!.message}.#{clear}")
+        ensure
+          file.unlink unless file_name
         end
-      ensure
-        file.unlink unless file_name
       end
     end
   end

--- a/lib/rails_wizard/recipe.rb
+++ b/lib/rails_wizard/recipe.rb
@@ -7,7 +7,7 @@ require 'erb'
 module RailsWizard
   class Recipe
     extend Comparable
-    
+
     def self.<=>(another)
       return -1 if another.run_after.include?(self.key) || self.run_before.include?(another.key)
       return 1 if another.run_before.include?(self.key) || self.run_after.include?(another.key)
@@ -37,8 +37,8 @@ module RailsWizard
       else
         template = template_or_file
       end
- 
-      recipe_class = Class.new(RailsWizard::Recipe) 
+
+      recipe_class = Class.new(RailsWizard::Recipe)
       recipe_class.attributes = attributes
       recipe_class.template = template
       recipe_class.key = key
@@ -95,12 +95,20 @@ module RailsWizard
     end
 
     def self.from_mongo(key)
-      return key if key.respond_to?(:superclass) && key.superclass == RailsWizard::Recipe
-      RailsWizard::Recipes[key]
+      return key if (key.respond_to?(:superclass) && key.superclass == RailsWizard::Recipe)
+      return RailsWizard::Recipes[key] if RailsWizard::Recipes[key]
+      raise(RailsWizard::UnknownRecipeError.new(key))
     end
 
     def self.get_binding
       binding
+    end
+  end
+
+  class UnknownRecipeError < StandardError
+    def initialize(key)
+      message = "No recipe found with name '#{key}'"
+      super(message)
     end
   end
 end

--- a/spec/rails_wizard/recipe_spec.rb
+++ b/spec/rails_wizard/recipe_spec.rb
@@ -41,7 +41,7 @@ name: This is an Example
 description: You know it's an exmaple.
 RUBY
         recipe = RailsWizard::Recipe.generate('just_a_test', file)
-        recipe.template.should == '# this is an example'        
+        recipe.template.should == '# this is an example'
         recipe.category.should == 'example'
         recipe.name.should == 'This is an Example'
       end
@@ -69,9 +69,35 @@ RUBY
 
   it 'should set default attributes' do
     recipe = RailsWizard::Recipe.generate('abc','# test')
-    
+
     RailsWizard::Recipe::DEFAULT_ATTRIBUTES.each_pair do |k,v|
       recipe.send(k).should == v
+    end
+  end
+
+  describe ".from_mongo" do
+    context "when asked for a known recipe" do
+      let(:recipe_key) {'recipe_example'}
+      let(:recipe) { RailsWizard::Recipe.generate(recipe_key, "# this is a test", :category => 'example', :name => "RailsWizard Example") }
+      let(:recipe_klass) { Kernel.const_get("RailsWizard").const_get("Recipes").const_get("RecipeExample") }
+      before :all do
+        RailsWizard::Recipes.add(recipe)
+      end
+      context "by key" do
+        it "returns the recipe" do
+          RailsWizard::Recipe.from_mongo(recipe_key).should == recipe_klass
+        end
+      end
+      context "by class" do
+        it "returns the recipe" do
+          RailsWizard::Recipe.from_mongo(recipe_klass).should == recipe_klass
+        end
+      end
+    end
+    context "when asked for an unknown recipe" do
+      it "raises an UnknownRecipeError" do
+        expect { RailsWizard::Recipe.from_mongo("foo") }.to raise_error RailsWizard::UnknownRecipeError, "No recipe found with name 'foo'"
+      end
     end
   end
 end


### PR DESCRIPTION
I used the rails_apps_composer new command with a long list of recipes in the -r argument and one of them was misspelled. I got a stack trace and it wasn't immediately obvious what the problem was. I thought it would be better if the command outputs a nice error message instead.
