### PR TITLE
Add Google Oauth2 Support

### DIFF
--- a/recipes/omniauth.rb
+++ b/recipes/omniauth.rb
@@ -15,6 +15,8 @@ if config['omniauth']
       gem 'omniauth-linkedin'
     when 'google'
       gem 'omniauth-google'
+    when 'google-oauth2'
+      gem 'omniauth-google-oauth2'
     when 'tumblr'
       gem 'omniauth-tumblr'
   end
@@ -189,4 +191,4 @@ config:
   - provider:
       type: multiple_choice
       prompt: "Which service provider will you use?"
-      choices: [["Twitter", twitter], ["Facebook", facebook], ["GitHub", github], ["LinkedIn", linkedin], ["Google", google], ["Tumblr", tumblr]]
+      choices: [["Twitter", twitter], ["Facebook", facebook], ["GitHub", github], ["LinkedIn", linkedin], ["Google", google], ["Google-Oauth-2",google-oauth2], ["Tumblr", tumblr]]


### PR DESCRIPTION
Hi All,

When using the Omniauth recipe with google it throws a bundler error. It seems the omniauth-google gem (https://github.com/Yesware/omniauth-google) has not has any commits in the last 6 months and isn't responding to the resquest to bump the version number. The omniauth-google-oauth2 gem does appear to be still supported and is I believe the preferred google approach now. It's located here (https://github.com/zquestz/omniauth-google-oauth2). 

~Earl 
