### PR TITLE
Create gemset if not created

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm ruby-1.9.3-p194@rails_apps_composer
+rvm ruby-1.9.3-p194@rails_apps_composer --create


### PR DESCRIPTION
If you don't already have the rails_apps_composer gemset, rvm will complain and not work.
