### PR TITLE
Fix that redacted_prefs delete the same keys in original prefs

### DIFF
--- a/templates/layout.erb
+++ b/templates/layout.erb
@@ -75,7 +75,7 @@ end
 # >---------------------------------[ Diagnostics ]----------------------------------<
 
 # remove prefs which are diagnostically irrelevant
-redacted_prefs = prefs
+redacted_prefs = prefs.clone
 redacted_prefs.delete(:git)
 redacted_prefs.delete(:dev_webserver)
 redacted_prefs.delete(:prod_webserver)


### PR DESCRIPTION
This issue results in `git :commit`s are not executed in `after_bundle` and `after_everything`.
