### PR TITLE
Fix incorrect database name(s) in database.yml

### DIFF
--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -124,6 +124,9 @@ after_bundler do
       say_wizard "Creating a user named '#{app_name}' for PostgreSQL"
       run "createuser #{app_name}" if prefer :database, 'postgresql'
       gsub_file "config/database.yml", /username: .*/, "username: #{app_name}"
+      gsub_file "config/database.yml", /database: myapp_development/, "database: #{app_name}_development"
+      gsub_file "config/database.yml", /database: myapp_test/,        "database: #{app_name}_test"
+      gsub_file "config/database.yml", /database: myapp_production/,  "database: #{app_name}_production"
     rescue StandardError
       raise "unable to create a user for PostgreSQL"
     end


### PR DESCRIPTION
When database.yml is generated, it uses the placeholder `myapp` as the application name. Previously, the gems recipe didn't parse out this name and replace it with the real application name, resulting in a required edit of the database.yml file. That has been resolved with this commit, which looks for the 3 default Rails environments and replaces their `myapp` with the desired name of the Rails application.
