### PR TITLE
Remove provider and uid from attr_accessible

### DIFF
--- a/recipes/models.rb
+++ b/recipes/models.rb
@@ -55,7 +55,7 @@ RUBY
     repo = 'https://raw.github.com/RailsApps/rails3-mongoid-omniauth/master/'
     copy_from_repo 'config/initializers/omniauth.rb', :repo => repo
     generate 'model User name:string email:string provider:string uid:string' unless prefer :orm, 'mongoid'
-    run 'bundle exec rake db:migrate' unless prefer :orm, 'mongoid' 
+    run 'bundle exec rake db:migrate' unless prefer :orm, 'mongoid'
     copy_from_repo 'app/models/user.rb', :repo => repo  # copy the User model (Mongoid version)
     unless prefer :orm, 'mongoid'
       ## OMNIAUTH AND ACTIVE RECORD
@@ -65,6 +65,7 @@ RUBY
       gsub_file 'app/models/user.rb', /^\s*# run 'rake db:mongoid:create_indexes' to create indexes\n/, ''
       gsub_file 'app/models/user.rb', /^\s*index\(\{ email: 1 \}, \{ unique: true, background: true \}\)\n/, ''
     end
+    gsub_file 'app/models/user.rb', /^\s*attr_accessible.*:provider.*$/, '  attr_accessible :name, :email'
   end
   ### SUBDOMAINS ###
   copy_from_repo 'app/models/user.rb', :repo => 'https://raw.github.com/RailsApps/rails3-subdomains/master/' if prefer :starter_app, 'subdomains_app'

--- a/spec/rails_wizard/recipes/models_spec.rb
+++ b/spec/rails_wizard/recipes/models_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+class DummyContext
+  attr_reader :preferences, :file_contents
+
+  def after_bundler; yield; end
+  def say_wizard(_); end
+  def git(*_); puts 'git called'; end
+  def generate(_); end
+  def run(_); end
+  def copy_from_repo(*_); end
+
+  def initialize
+    @preferences = []
+    @file_contents = <<-USER_RB
+class User < ActiveRecord::Base
+  attr_accessible :name, :email, :provider, :uid
+end
+USER_RB
+  end
+
+  def gsub_file file, needle, replace
+    if file == 'app/models/user.rb'
+      @file_contents.gsub!(needle, replace)
+    end
+  end
+
+  def prefer *attrs
+    @preferences.include?(attrs)
+  end
+end
+
+describe 'models recipe' do
+  subject { DummyContext.new }
+  let(:proj_root) { File.expand_path('../../../..', __FILE__) }
+  describe 'security' do
+    describe 'for omniauth' do
+      it 'does not set uid or provider as attr_accessible' do
+        subject.preferences << [:authentication, 'omniauth']
+        file_under_test = File.read("#{proj_root}/recipes/models.rb")
+        subject.instance_eval(file_under_test)
+        subject.file_contents.should_not match(/attr_accessible.*:uid/)
+        subject.file_contents.should_not match(/attr_accessible.*:provider/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Leaving `:provider` and `:uid` in the user model's `attr_accessible` list constitutes a security risk.

Not sure if this needs to be addressed in more places. :/
