### PR TITLE
Change template root

### DIFF
--- a/CHANGELOG.textile
+++ b/CHANGELOG.textile
@@ -1,5 +1,9 @@
 h1. CHANGELOG
 
+h2. 2.2.17 unreleased
+
+* add '-L' flag to clear the default recipes so only local recipes are available (contributed by Clinton N. Dreisbach)
+
 h2. 2.2.16 October 24, 2012
 
 * add 'saas' recipe for rails-stripe-membership-saas example app

--- a/README.textile
+++ b/README.textile
@@ -140,6 +140,8 @@ $ rails_apps_composer new myapp -l ~/recipes/
 
 If you create local recipes, please consider contributing them to the project.
 
+If you want to only use your local recipes, and not include the default recipes, use the @-L@ flag.
+
 h3. Generate an Application Interactively
 
 You'll be prompted for recipes and gems:

--- a/lib/rails_wizard/command.rb
+++ b/lib/rails_wizard/command.rb
@@ -8,6 +8,7 @@ module RailsWizard
     method_option :recipes, :type => :array, :aliases => "-r"
     method_option :defaults, :type => :string, :aliases => "-d"
     method_option :recipe_dirs, :type => :array, :aliases => "-l"
+    method_option :no_default_recipes, :type => :boolean, :aliases => "-L"
     method_option :template_root, :type => :string, :aliases => '-t'
     method_option :quiet, :type => :boolean, :aliases => "-q", :default => false
     def new(name)
@@ -23,6 +24,7 @@ module RailsWizard
     method_option :recipes, :type => :array, :aliases => "-r"
     method_option :defaults, :type => :string, :aliases => "-d"
     method_option :recipe_dirs, :type => :array, :aliases => "-l"
+    method_option :no_default_recipes, :type => :boolean, :aliases => "-L"
     method_option :template_root, :type => :string, :aliases => '-t'
     method_option :quiet, :type => :boolean, :aliases => "-q", :default => false
     def template(template_name)
@@ -56,6 +58,7 @@ module RailsWizard
       def yellow; "\033[33m" end
 
       def add_recipes
+        Recipes.clear if options[:no_default_recipes]
         if dirs = options[:recipe_dirs]
           dirs.each { |d| Recipes.add_from_directory(d) }
         end

--- a/lib/rails_wizard/recipes.rb
+++ b/lib/rails_wizard/recipes.rb
@@ -2,13 +2,21 @@ module RailsWizard
   module Recipes
     @@categories = {}
     @@list = {}
-    
+
     def self.add(recipe)
       RailsWizard::Recipes.const_set ActiveSupport::Inflector.camelize(recipe.key), recipe
       @@list[recipe.key] = recipe
       (@@categories[recipe.category.to_s] ||= []) << recipe.key
       @@categories[recipe.category.to_s].uniq!
       recipe
+    end
+
+    def self.clear
+      self.list.each do |recipe_key|
+        send(:remove_const, ActiveSupport::Inflector.camelize(recipe_key))
+      end
+      @@categories = {}
+      @@list = {}
     end
 
     def self.[](key)

--- a/spec/rails_wizard/recipes_spec.rb
+++ b/spec/rails_wizard/recipes_spec.rb
@@ -26,4 +26,12 @@ describe RailsWizard::Recipes do
     subject.add_from_directory(File.join(File.dirname(__FILE__), '..', 'test_recipes'))
     subject.list.should include 'test_recipe_in_file'
   end
+
+  describe '.clear' do
+    it 'should remove all current recipes' do
+      RailsWizard::Recipes.clear
+      subject.list.should == []
+      subject.categories.should == []
+    end
+  end
 end


### PR DESCRIPTION
Like in our "clear default recipes" branch, we have found that we want to change the defaults. In this case, we want to change layout of our generated template file. Instead of forking rails_apps_composer and using our fork to do this, we think it makes more sense to have our own set of templates that we use. We have added a `-t` flag to set the template root.
