### PR TITLE
Added that precious little asterisk

### DIFF
--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -116,7 +116,7 @@ end
 
 ## Gems from a defaults file or added interactively
 gems.each do |g|
-  gem g
+  gem(*g)
 end
 
 ## Git


### PR DESCRIPTION
I wanted to be able to specify a gem's origin (say on github) or include other arguments to gem. I added just one little asterisk, and now you can specify gems from a particular source like this in your app's starter yaml file.

```
recipes:
  - gems

gems:
  - 
    - "css_canon"
    - :git: 'https://github.com/lastobelus/css_canon'
```

Of you could pass whatever arguments you like to gem. Good times!
