### PR TITLE
Lengthen default testing password

### DIFF
--- a/recipes/testing.rb
+++ b/recipes/testing.rb
@@ -244,8 +244,8 @@ RUBY
 Fabricator(:user) do
   name     'Test User'
   email    'example@example.com'
-  password 'please'
-  password_confirmation 'please'
+  password 'password'
+  password_confirmation 'password'
   # required if the Devise Confirmable module is used
   # confirmed_at Time.now
 end


### PR DESCRIPTION
After app generation tests were failing due to change in Devise defaults (https://github.com/plataformatec/devise/commit/2950434ed344610770ad83dd77c9f45b9f01713c). Increased default test password length so tests pass again.
