### PR TITLE
Don't install binding_of_caller gem for JRuby and non-MRI/Rubinius cases

### DIFF
--- a/recipes/extras.rb
+++ b/recipes/extras.rb
@@ -26,7 +26,7 @@ end
 if prefs[:better_errors]
   say_wizard "recipe adding better_errors gem"
   gem 'better_errors', '>= 0.6.0', :group => :development
-  gem 'binding_of_caller', '>= 0.6.9', :group => :development
+  gem 'binding_of_caller', '>= 0.6.9', :group => :development, :platforms => [:mri_19, :rbx]
 end
 
 ## BAN SPIDERS


### PR DESCRIPTION
I added a :platforms group to the binding_of_caller gem to prevent it from being installed in non-MRI/Rubinius Ruby implementations (JRuby, et al)

https://github.com/banister/binding_of_caller

http://gembundler.com/man/gemfile.5.html
