### PR TITLE
Support for Guard

### DIFF
--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -63,6 +63,15 @@ if prefer :integration, 'cucumber'
   gem 'capybara', '>= 2.0.3', :group => :test
 end
 gem 'turnip', '>= 1.1.0', :group => :test if prefer :integration, 'turnip'
+if prefer :continuous_testing, 'guard'
+  gem 'guard-bundler', '>= 1.0.0', :group => :development
+  gem 'guard-cucumber', '>= 1.4.0', :group => :development if prefer :integration, 'cucumber'
+  gem 'guard-rails', '>= 0.4.0', :group => :development
+  gem 'guard-rspec', '>= 2.5.2', :group => :development if prefer :unit_test, 'rspec'
+  gem 'rb-inotify', '>= 0.9.0', :group => :development, :require => false
+  gem 'rb-fsevent', '>= 0.9.3', :group => :development, :require => false
+  gem 'rb-fchange', '>= 0.0.6', :group => :development, :require => false
+end
 gem 'factory_girl_rails', '>= 4.2.0', :group => [:development, :test] if prefer :fixtures, 'factory_girl'
 gem 'fabrication', '>= 2.3.0', :group => [:development, :test] if prefer :fixtures, 'fabrication'
 gem 'machinist', '>= 2.0', :group => :test if prefer :fixtures, 'machinist'

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -56,6 +56,7 @@ if recipes.include? 'testing'
   prefs[:unit_test] = multiple_choice "Unit testing?", [["Test::Unit", "test_unit"], ["RSpec", "rspec"], ["MiniTest", "minitest"]] unless prefs.has_key? :unit_test
   prefs[:integration] = multiple_choice "Integration testing?", [["None", "none"], ["RSpec with Capybara", "rspec-capybara"],
     ["Cucumber with Capybara", "cucumber"], ["Turnip with Capybara", "turnip"], ["MiniTest with Capybara", "minitest-capybara"]] unless prefs.has_key? :integration
+  prefs[:continuous_testing] = multiple_choice "Continuous testing?", [["None", "none"], ["Guard", "guard"]] unless prefs.has_key? :continuous_testing
   prefs[:fixtures] = multiple_choice "Fixture replacement?", [["None","none"], ["Factory Girl","factory_girl"], ["Machinist","machinist"], ["Fabrication","fabrication"]] unless prefs.has_key? :fixtures
 end
 

--- a/recipes/testing.rb
+++ b/recipes/testing.rb
@@ -102,6 +102,11 @@ RUBY
     say_wizard "generating blueprints file for 'machinist'"
     generate 'machinist:install'
   end
+  ### GUARD
+  if prefer :continuous_testing, 'guard'
+    say_wizard "recipe initializing Guard"
+    run 'bundle exec guard init'
+  end
   ### GIT ###
   git :add => '-A' if prefer :git, true
   git :commit => '-qm "rails_apps_composer: testing framework"' if prefer :git, true


### PR DESCRIPTION
Support for continuous testing using Guard as discussed on https://github.com/RailsApps/rails-composer/issues/91

Plugins for Bundler and Rails get installed by default when selecting Guard. Plugins for RSpec and Cucumber will install as needed. Support for monitoring filesystem changes in different operating systems (Linux, OS X, Windows) gets installed just by including all three gems as described in Guard docs.
