### PR TITLE
Pull request to stop deprecation warnings about combining `let` with `before(:all)`

### DIFF
--- a/spec/rails_wizard/recipe_spec.rb
+++ b/spec/rails_wizard/recipe_spec.rb
@@ -78,9 +78,19 @@ RUBY
   describe ".from_mongo" do
     context "when asked for a known recipe" do
       let(:recipe_key) {'recipe_example'}
-      let(:recipe) { RailsWizard::Recipe.generate(recipe_key, "# this is a test", :category => 'example', :name => "RailsWizard Example") }
-      let(:recipe_klass) { Kernel.const_get("RailsWizard").const_get("Recipes").const_get("RecipeExample") }
-      before :all do
+      let(:recipe) do
+        RailsWizard::Recipe.generate( recipe_key, '# this is a test', {
+            :category => 'example',
+            :name     => 'RailsWizard Example',
+            } )
+      end
+      let(:recipe_klass) do
+        Kernel.const_get('RailsWizard'  ).
+               const_get('Recipes'      ).
+               const_get('RecipeExample')
+      end
+
+      before do
         RailsWizard::Recipes.add(recipe)
       end
       context "by key" do

--- a/spec/rails_wizard/recipes_spec.rb
+++ b/spec/rails_wizard/recipes_spec.rb
@@ -2,9 +2,15 @@ require 'spec_helper'
 
 describe RailsWizard::Recipes do
   subject{ RailsWizard::Recipes }
-  let(:recipe){ RailsWizard::Recipe.generate("recipe_test", "# Testing", :name => "Test Recipe", :category => "test", :description => "Just a test.")}
+  let(:recipe) do
+    RailsWizard::Recipe.generate( "recipe_test", "# Testing", {
+        :category    =>        'test',
+        :description => 'Just a test.',
+        :name        =>        'Test Recipe',
+        } )
+  end
 
-  before(:all) do
+  before do
     RailsWizard::Recipes.add(recipe)
   end
 


### PR DESCRIPTION
Changes `before(:all)` to `before(:each)` to stop certain RSpec deprecation warnings explained [here](https://github.com/rspec/rspec-core/pull/823#issuecomment-16590800) about combining `let` with `before(:all)`. RSpec 3.0 promises to [disallow](https://github.com/rspec/rspec-core/pull/823) this combination.

The `let` statements' readability is improved also.

All tests now pass without warnings.

One of the three similar warnings emitted by `rake spec` was:

```
WARNING: let declaration `recipe` accessed in a `before(:all)` hook at:
rails_apps_composer/spec/rails_wizard/recipe_spec.rb:94.
This is deprecated behavior that will not be supported in RSpec 3.

`let` and `subject` declarations are not intended to be called
in a `before(:all)` hook, as they exist to define state that
is reset between each example, while `before(:all)` exists to
define state that is shared across examples in an example group.
```
