### PR TITLE
Pull request to prevent constant redefinition in tests

### DIFF
--- a/spec/rails_wizard/recipe_spec.rb
+++ b/spec/rails_wizard/recipe_spec.rb
@@ -77,33 +77,31 @@ RUBY
 
   describe ".from_mongo" do
     context "when asked for a known recipe" do
-      let(:recipe_key) {'recipe_example'}
-      let(:recipe) do
-        RailsWizard::Recipe.generate( recipe_key, '# this is a test', {
+      before(:all) do
+        @recipe_key = 'recipe_example'
+        @recipe = RailsWizard::Recipe.generate(@recipe_key, '# this is a test', {
             :category => 'example',
             :name     => 'RailsWizard Example',
             } )
-      end
-      let(:recipe_klass) do
-        Kernel.const_get('RailsWizard'  ).
-               const_get('Recipes'      ).
-               const_get('RecipeExample')
+        RailsWizard::Recipes.add(@recipe)
+        @recipe_klass = Kernel.
+            const_get('RailsWizard'  ).
+            const_get('Recipes'      ).
+            const_get('RecipeExample')
       end
 
-      before do
-        RailsWizard::Recipes.add(recipe)
-      end
       context "by key" do
         it "returns the recipe" do
-          RailsWizard::Recipe.from_mongo(recipe_key).should == recipe_klass
+          RailsWizard::Recipe.from_mongo(@recipe_key).should == @recipe_klass
         end
       end
       context "by class" do
         it "returns the recipe" do
-          RailsWizard::Recipe.from_mongo(recipe_klass).should == recipe_klass
+          RailsWizard::Recipe.from_mongo(@recipe_klass).should == @recipe_klass
         end
       end
     end
+
     context "when asked for an unknown recipe" do
       it "raises an UnknownRecipeError" do
         expect { RailsWizard::Recipe.from_mongo("foo") }.to raise_error RailsWizard::UnknownRecipeError, "No recipe found with name 'foo'"

--- a/spec/rails_wizard/recipes_spec.rb
+++ b/spec/rails_wizard/recipes_spec.rb
@@ -2,20 +2,18 @@ require 'spec_helper'
 
 describe RailsWizard::Recipes do
   subject{ RailsWizard::Recipes }
-  let(:recipe) do
-    RailsWizard::Recipe.generate( "recipe_test", "# Testing", {
+
+  before(:all) do
+    @recipe = RailsWizard::Recipe.generate( "recipe_test", "# Testing", {
         :category    =>        'test',
         :description => 'Just a test.',
         :name        =>        'Test Recipe',
         } )
-  end
-
-  before do
-    RailsWizard::Recipes.add(recipe)
+    RailsWizard::Recipes.add(@recipe)
   end
 
   it '.list_classes should include recipe classes' do
-    subject.list_classes.should be_include(recipe)
+    subject.list_classes.should be_include(@recipe)
   end
 
   it '.list should include recipe keys' do


### PR DESCRIPTION
During testing, RSpec warns of a constant being redefined, probably due to adopting before(:each) in pull request #193.

This (new) request reverts back to `before(:all)`. But it replaces the conflicting `let` statements with instance variables, per this insightful [comment](http://stackoverflow.com/questions/5359558/when-to-use-rspec-let#comment14970850_9994464) by principal RSpec maintainer Myron Marston.

All tests pass.
