### PR TITLE
Add selenium-webdriver to rails-prelaunch-signup

### DIFF
--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -129,6 +129,7 @@ end
 ## Signup App
 if prefer :railsapps, 'rails-prelaunch-signup'
   gem 'gibbon', '>= 0.4.2'
+  gem 'selenium-webdriver', '~> 2.32.1'
 end
 
 ## Gems from a defaults file or added interactively


### PR DESCRIPTION
Need to add selenium webdriver gem for cucumber testing of all the javascript modals. 
