### PR TITLE
Only require capybara-webkit in test environment for rails prelaunch

### DIFF
--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -129,7 +129,7 @@ end
 ## Signup App
 if prefer :railsapps, 'rails-prelaunch-signup'
   gem 'gibbon', '>= 0.4.2'
-  gem 'capybara-webkit', '~> 1.0.0'
+  gem 'capybara-webkit', '~> 1.0.0', :group => :test
 end
 
 ## Gems from a defaults file or added interactively


### PR DESCRIPTION
Sorry Daniel, forgot to only include this gem in test environment group. Heroku will blow up on 'bundle exec' when you deploy unless its in the 'test' group. 
