### PR TITLE
Pull request creating Meetup OmniAuth Rails Example App

### DIFF
--- a/recipes/controllers.rb
+++ b/recipes/controllers.rb
@@ -46,6 +46,13 @@ RUBY
     filename = 'app/controllers/sessions_controller.rb'
     copy_from_repo filename, :repo => 'https://raw.github.com/RailsApps/rails3-mongoid-omniauth/master/'
     gsub_file filename, /twitter/, prefs[:omniauth_provider] unless prefer :omniauth_provider, 'twitter'
+    if prefer :collect_user_email, false
+      gsub_file filename, /^\s*if user.email.blank\?$.*?^\s*end$\n/m do
+    <<-RUBY
+    redirect_to root_url, :notice => 'Signed in!'
+RUBY
+      end
+    end
     if prefer :authorization, 'cancan'
       inject_into_file filename, "    user.add_role :admin if User.count == 1 # make the first user an admin\n", :after => "session[:user_id] = user.id\n"
     end

--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -103,6 +103,7 @@ gem 'omniauth-github' if prefer :omniauth_provider, 'github'
 gem 'omniauth-linkedin' if prefer :omniauth_provider, 'linkedin'
 gem 'omniauth-google-oauth2' if prefer :omniauth_provider, 'google_oauth2'
 gem 'omniauth-tumblr' if prefer :omniauth_provider, 'tumblr'
+gem 'omniauth-meetup' if prefer :omniauth_provider, 'meetup'
 
 ## Authorization
 if prefer :authorization, 'cancan'

--- a/recipes/models.rb
+++ b/recipes/models.rb
@@ -65,8 +65,18 @@ RUBY
       gsub_file 'app/models/user.rb', /class User/, 'class User < ActiveRecord::Base'
       gsub_file 'app/models/user.rb', /^\s*include Mongoid::Document\n/, ''
       gsub_file 'app/models/user.rb', /^\s*field.*\n/, ''
+    else
+      if prefer :collect_user_email, false
+        gsub_file 'app/models/user.rb', /^\s*field :email, type: String\n/, ''
+      end
+    end
+    if (prefer :collect_user_email, false) || !(prefer :orm, 'mongoid')
       gsub_file 'app/models/user.rb', /^\s*# run 'rake db:mongoid:create_indexes' to create indexes\n/, ''
       gsub_file 'app/models/user.rb', /^\s*index\(\{ email: 1 \}, \{ unique: true, background: true \}\)\n/, ''
+    end
+    if prefer :collect_user_email, false
+      gsub_file 'app/models/user.rb', /^(\s*attr_accessible :provider, :uid, :name), :email(\n)/, '\\1\\2'
+      gsub_file 'app/models/user.rb', /^\s*user\.email =.*\n/, ''
     end
   end
   ### SUBDOMAINS ###

--- a/recipes/railsapps.rb
+++ b/recipes/railsapps.rb
@@ -9,7 +9,9 @@ prefs[:railsapps] = multiple_choice "Install an example application?",
   ["rails3-devise-rspec-cucumber", "rails3-devise-rspec-cucumber"],
   ["rails3-mongoid-devise", "rails3-mongoid-devise"],
   ["rails3-mongoid-omniauth", "rails3-mongoid-omniauth"],
-  ["rails3-subdomains", "rails3-subdomains"]] unless prefs.has_key? :railsapps
+  ["rails3-subdomains", "rails3-subdomains"],
+  ["rails3-mongoid-omniauth-meetup", "rails3-mongoid-omniauth-meetup"],
+  ] unless prefs.has_key? :railsapps
 
 case prefs[:railsapps]
   when 'saas'
@@ -161,6 +163,24 @@ case prefs[:railsapps]
     prefs[:quiet_assets] = true
     prefs[:local_env_file] = true
     prefs[:better_errors] = true
+  when 'rails3-mongoid-omniauth-meetup'
+    prefs[:git] = true
+    prefs[:database] = 'mongodb'
+    prefs[:orm] = 'mongoid'
+    prefs[:unit_test] = 'rspec'
+    prefs[:integration] = 'cucumber'
+    prefs[:fixtures] = 'factory_girl'
+    prefs[:frontend] = 'none'
+    prefs[:email] = 'none'
+    prefs[:authentication] = 'omniauth'
+    prefs[:omniauth_provider] = 'meetup'
+    prefs[:authorization] = 'none'
+    prefs[:starter_app] = 'users_app'
+    prefs[:form_builder] = 'none'
+    prefs[:quiet_assets] = true
+    prefs[:local_env_file] = true
+    prefs[:better_errors] = true
+    prefs[:collect_user_email] = false
   when 'rails3-subdomains'
     prefs[:git] = true
     prefs[:database] = 'mongodb'

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -93,8 +93,10 @@ if recipes.include? 'models'
           ["Devise with Confirmable and Invitable modules","invitable"]] unless prefs.has_key? :devise_modules
       end
     when 'omniauth'
-      prefs[:omniauth_provider] = multiple_choice "OmniAuth provider?", [["Facebook", "facebook"], ["Twitter", "twitter"], ["GitHub", "github"],
-        ["LinkedIn", "linkedin"], ["Google-Oauth-2", "google_oauth2"], ["Tumblr", "tumblr"]] unless prefs.has_key? :omniauth_provider
+      prefs[:omniauth_provider] = multiple_choice "OmniAuth provider?", [
+        ["Facebook", "facebook"], ["Twitter", "twitter"], ["GitHub", "github"], ["LinkedIn", "linkedin"],
+        ["Google-Oauth-2", "google_oauth2"], ["Tumblr", "tumblr"], ["Meetup", "meetup"],
+        ] unless prefs.has_key? :omniauth_provider
   end
   prefs[:authorization] = multiple_choice "Authorization?", [["None", "none"], ["CanCan with Rolify", "cancan"]] unless prefs.has_key? :authorization
 end

--- a/recipes/testing.rb
+++ b/recipes/testing.rb
@@ -151,7 +151,17 @@ after_everything do
       say_wizard "copying RSpec files from the rails3-mongoid-omniauth examples"
       repo = 'https://raw.github.com/RailsApps/rails3-mongoid-omniauth/master/'
       copy_from_repo 'spec/factories/users.rb', :repo => repo
+      gsub_file      'spec/factories/users.rb',
+        /twitter/, prefs[:omniauth_provider] unless prefer :omniauth_provider, 'twitter'
       copy_from_repo 'spec/controllers/sessions_controller_spec.rb', :repo => repo
+      gsub_file      'spec/controllers/sessions_controller_spec.rb',
+        /twitter/, prefs[:omniauth_provider] unless prefer :omniauth_provider, 'twitter'
+      if prefer :collect_user_email, false
+        gsub_file    'spec/controllers/sessions_controller_spec.rb',
+          /^(\s*it "redirects )new (users )with blank email to fill in their email(" do\n)/, '\\1\\2back to root_url\\3'
+        gsub_file    'spec/controllers/sessions_controller_spec.rb',
+          /^\s*page.should have_content\('Please enter your email address'\)$.*?^\s*visit '\/signin'$\n/m, ''
+      end
       copy_from_repo 'spec/controllers/home_controller_spec.rb', :repo => repo
       copy_from_repo 'spec/controllers/users_controller_spec.rb', :repo => repo
       copy_from_repo 'spec/models/user_spec.rb', :repo => repo

--- a/recipes/views.rb
+++ b/recipes/views.rb
@@ -35,9 +35,19 @@ after_bundler do
     end
     ## SHOW
     copy_from_repo 'app/views/users/show.html.erb'
+    if prefer :collect_user_email, false
+      unless (prefer :templates, 'haml') || (prefer :templates, 'slim')
+        gsub_file  'app/views/users/show.html.erb', /^\s*<p>Email:.*\n/, ''
+      end
+    end
     copy_from_repo 'app/views/users/show-subdomains_app.html.erb', :prefs => 'subdomains_app'
     ## EDIT
     copy_from_repo 'app/views/users/edit-omniauth.html.erb', :prefs => 'omniauth'
+    if prefer :collect_user_email, false
+      unless (prefer :templates, 'haml') || (prefer :templates, 'slim')
+        gsub_file 'app/views/users/edit.html.erb', /^\s*<%= f\.label :email.*?^\s*<br \/>$\n/m, ''
+      end
+    end
   end
   ### PROFILES ###
   copy_from_repo 'app/views/profiles/show-subdomains_app.html.erb', :prefs => 'subdomains_app'


### PR DESCRIPTION
Adds to the RailsApps OmniAuth authentication menu the option of using Meetup.

Corrects issue #216 so now any preferred OmniAuth provider replaces the default (Twitter) in tests.

Creates a new preference, 'collect_user_email.' If false, this strips all email-related code which otherwise runs during user registration from any generated OmniAuth Rails Example App.

Creates a new Rails Example App, 'rails3-mongoid-omniauth-meetup,' which:
- Utilizes OmniAuth Meetup authentication; and
- Doesn't collect users' email addresses.

Alters the tests from 'rails3-mongoid-omniauth' for the new Rails Example App.

BTW, as of yet, generating the new Rails Example App draws no code from itself. Instead, similar code is drawn from existing Rails Example App, 'rails3-mongoid-omniauth.'

The new app was tested using ERB. No attempt has been made (yet) to remove (if requested) the user registration email-related functionality from the Haml or Slim view translations. That would seem to require something more subtle in the [copy_from_repo](https://github.com/RailsApps/rails_apps_composer/blob/master/templates/helpers.erb#L61) method.

With that caveat, all gem, 'rails_apps_composer' tests pass, and it generates the RailsApps template with no error messages.

All tests pass in the following Rails Example Apps (and they generate with no error messages):
- The new Rails Example App;
- Existing Rails Example App, 'rails3-mongoid-omniauth.'

The two regenerated Rails Example Apps (above) seem to work fine, and browser login and logout succeeds.
