### PR TITLE
Better Rails 4.0 support and html2haml fix

### DIFF
--- a/CHANGELOG.textile
+++ b/CHANGELOG.textile
@@ -1,5 +1,13 @@
 h1. CHANGELOG
 
+h2. 2.4.1 June 25, 2013
+
+* add 'protected_attributes' gem for Rails 4.0
+* fix devise 'routes.rb' file for Rails 4.0
+* fix cancan 'seeds.rb' file for Rails 4.0
+* add gem paths reload command to fix 'html2haml' requirement
+* upgrade 'simple_form' gem to '3.0.0.rc' for Rails 4.0
+
 h2. 2.4.0 June 24, 2013
 
 * preliminary menus for Rails 4.0

--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -20,6 +20,9 @@ else
   add_gem 'puma', :group => :production if prefer :prod_webserver, 'puma'
 end
 
+## Rails 4.0 attr_accessible Compatibility
+add_gem 'protected_attributes' if Rails::VERSION::MAJOR.to_s == "4"
+
 ## Database Adapter
 gsub_file 'Gemfile', /gem 'sqlite3'\n/, '' unless prefer :database, 'sqlite'
 add_gem 'mongoid' if prefer :orm, 'mongoid'
@@ -111,7 +114,11 @@ if prefer :authorization, 'cancan'
 end
 
 ## Form Builder
-add_gem 'simple_form' if prefer :form_builder, 'simple_form'
+if Rails::VERSION::MAJOR.to_s == "4"
+  add_gem 'simple_form', '~> 3.0.0.rc' if prefer :form_builder, 'simple_form'
+else
+  add_gem 'simple_form' if prefer :form_builder, 'simple_form'
+end
 
 ## Membership App
 if prefer :railsapps, 'rails-stripe-membership-saas'

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -61,6 +61,8 @@ YAML.load(ENV['ROLES']).each do |role|
 end
 FILE
       end
+      ## Fix db seed for Rails 4.0
+      gsub_file 'db/seeds.rb', /{ :name => role }/, 'role' if Rails::VERSION::MAJOR.to_s == "4"
     else
       append_file 'db/seeds.rb' do <<-FILE
 puts 'ROLES'

--- a/recipes/routes.rb
+++ b/recipes/routes.rb
@@ -11,7 +11,11 @@ after_bundler do
   ### USER_ACCOUNTS ###
   if ['users_app','admin_app'].include? prefs[:starter_app]
     ## DEVISE
-    copy_from_repo 'config/routes.rb', :repo => 'https://raw.github.com/RailsApps/rails3-devise-rspec-cucumber/master/' if prefer :authentication, 'devise'
+    if prefer :authentication, 'devise'
+      copy_from_repo 'config/routes.rb', :repo => 'https://raw.github.com/RailsApps/rails3-devise-rspec-cucumber/master/'
+      ## Rails 4.0 doesn't allow two 'root' routes
+      gsub_file 'config/routes.rb', /authenticated :user do\n.*\n.*\n  /, '' if Rails::VERSION::MAJOR.to_s == "4"
+    end
     ## OMNIAUTH
     copy_from_repo 'config/routes.rb', :repo => 'https://raw.github.com/RailsApps/rails3-mongoid-omniauth/master/' if prefer :authentication, 'omniauth'
   end

--- a/templates/layout.erb
+++ b/templates/layout.erb
@@ -196,7 +196,8 @@ if prefs.has_key? :bundle_path
 else
   run 'bundle install --without production'
 end
-
+say_wizard "Updating gem paths."
+Gem.clear_paths
 # >-----------------------------[ Run 'After Bundler' Callbacks ]-------------------------------<
 
 say_wizard "Running 'after bundler' callbacks."

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 module RailsWizard
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
 end


### PR DESCRIPTION
- Several minor updates to make devise + cancan code work with Rails 4.0.0 (release).
- Added gem path reload command just after **bundle install** to make sure we won't run into problems with missing gems while doing **require 'html2haml'**

It was sort of a quick fix for those wanting to start right now. For better and deeper Rails 4 integration a full revision of all dependencies is required.
