### PR TITLE
Pull request for mega-test on Mac OS X (and NetBSD)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ namespace :mega do
       mega:generated:env_vars
       mega:generated:test
       ] do
-    puts "\nCongratulations! Your megatest is successfully complete.\n\n"
+    puts "\nCongratulations! Your megatest has successfully completed.\n\n"
   end
 
   namespace :cloned do

--- a/megatest/README-NetBSD.txt
+++ b/megatest/README-NetBSD.txt
@@ -1,0 +1,15 @@
+Setup note for NetBSD:
+
+On NetBSD (as of version 6.0), 'sed' lacks an -i option, so use 
+package gsed instead:
+
+(
+  pkgin install gsed
+  cd /usr/bin
+  mv sed old-sed
+  ln -s /usr/pkg/bin/gsed sed
+  ls -ld *sed*
+  sed --version | grep GNU || echo failed
+)
+
+If this worked, the word GNU should be printed at least once.

--- a/megatest/README.txt
+++ b/megatest/README.txt
@@ -1,14 +1,36 @@
-Here are the steps to run megatest:
+For anyone changing gem rails_apps_composer, this mega-test gives it 
+a new and fuller testing capability (than previously available). To 
+accomplish this, it generates all Rails Example Apps and runs their 
+tests.
 
-bundle install
-rmdir ../generated
+The mega-test should work on Linux, Mac OS X, and NetBSD. (For the 
+last, please see the separate README.)
 
-# Run the megatest script with your service keys:
+How to run the mega-test:
+
+# Be in the right directory:
+cd rails_apps_composer
+
+# Each time you change the gem, do this:
 (
+  bundle install
+  gem uninstall rails_apps_composer -x
+  bundle exec rake reinstall
+)
+
+# To run the mega-test script, some Rails Example Apps require your 
+# service keys. So, do make a private copy of this file (not under 
+# version control), then edit it, putting in your own keys.
+
+# Run the mega-test:
+(
+# First, supply your service keys:
   export        rac_test_RECURLY_API_KEY=Change_this_to_your_key
   export rac_test_RECURLY_JS_PRIVATE_KEY=Change_this_to_your_key
   export         rac_test_STRIPE_API_KEY=Change_this_to_your_key
   export      rac_test_STRIPE_PUBLIC_KEY=Change_this_to_your_key
 
+# Then run the mega-test's Rake task:
+  rm -rf ../generated
   bundle exec rake mega:test --trace
 )


### PR DESCRIPTION
This supports contributors who use Mac OS X (recognizably, they are legion) by increasing the mega-test's shell and Unix utility portability. Presumably this will resolve issue #236.

Not having a Mac, and since Mac OS X was developed ultimately from BSD Unix, I developed these changes on an Amazon AWS instance running NetBSD (version 6.0).

Now, the mega-test successfully completes, both in the NetBSD shell (much different from BASH) on NetBSD, and in BASH on Linux. Generally, this should increase its portability and improve its operability (presumably) on Mac OS X.

Naturally, however, the mega-test cannot succeed if any Rails Example App repository already (currently) contains a failing test.

The tests for gem r_a_c continue to pass as well, both for NetBSD and Linux.

References:
[Mac OS X history](http://en.wikipedia.org/w/index.php?title=OS_X&oldid=565555321#History)
[NeXTSTEP description](http://en.wikipedia.org/w/index.php?title=NeXTSTEP&oldid=564657111#Description)
