### PR TITLE
mri_20 platform support for binding_of_caller

### DIFF
--- a/recipes/extras.rb
+++ b/recipes/extras.rb
@@ -91,7 +91,7 @@ end
 if prefs[:better_errors]
   say_wizard "recipe adding better_errors gem"
   add_gem 'better_errors', :group => :development
-  add_gem 'binding_of_caller', :group => :development, :platforms => [:mri_19, :rbx]
+  add_gem 'binding_of_caller', :group => :development, :platforms => [:mri_19, :mri_20, :rbx]
 end
 
 ## BAN SPIDERS


### PR DESCRIPTION
Added mri_20 platform support for binding_of_caller gem.
Originally only mri_19 and rbx were supported.
