### PR TITLE
use Kernel.load for defaults file, allowing to load defaults from http

### DIFF
--- a/lib/rails_wizard/command.rb
+++ b/lib/rails_wizard/command.rb
@@ -67,7 +67,7 @@ module RailsWizard
         # Load defaults from a file; if a file specifies recipes, they'll be run *before*
         # any on the command line (or prompted for)..
         return [[], {}] unless options[:defaults]
-        defaults = File.open(options[:defaults]) {|f| YAML.load(f) }
+        defaults = Kernel.open(options[:defaults]) {|f| YAML.load(f) }
         recipes = defaults.delete('recipes') { [] }
         [recipes, defaults]
       end


### PR DESCRIPTION
I would love to be able to use it like this

```
   rails_apps_composer new myapp -q -d https://github.com/demental/rails_apps_composer_defaults/blob/master/defaults/rails4_boostrap3.yaml
```
