### PR TITLE
Remove .gitignore and .gitkeep files unless git recipe is chosen

### DIFF
--- a/recipes/git.rb
+++ b/recipes/git.rb
@@ -9,6 +9,12 @@ if prefer :git, true
   git :init
   git :add => '-A'
   git :commit => '-qm "rails_apps_composer: initial commit"'
+else
+  after_everything do
+    say_wizard "removing .gitignore and .gitkeep files"
+    git_files = Dir[File.join('**','.gitkeep')] + Dir[File.join('**','.gitignore')]
+    File.unlink git_files
+  end
 end
 
 __END__


### PR DESCRIPTION
Fixes RailsApps/rails-composer#97. That's an issue I opened a some time ago.

Only now got around to write this small piece of code. Better late than never, though. :)
