### PR TITLE
Added note about rvm gem dependency when using project-specific gemset.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -58,6 +58,10 @@ h4. Database
 
 Unless you use SQLite, which runs by default on Mac OS X, you'll need to have a database server running before you run rails_apps_composer. This is true if you want to use PostgreSQL, MySQL, or MongoDB. I recommend using SQLite if you don't want to set up a database server.
 
+h4. RVM
+
+If using the project-specific RVM gemset from the "extras" recipe, both RVM and the "rvm" gem are needed to be installed as well.
+
 h2. Installation and Usage
 
 I recommend installing and using RVM, the "Ruby Version Manager":https://rvm.io/, to create a new gemset for rails_apps_composer. Using an RVM gemset will make it easier to identify and isolate incompatibilities among gems. RVM will install Ruby and set up a global gemset with a minimal set of gems.
@@ -70,6 +74,7 @@ $ cd myapp
 $ rvm use ruby-2.0.0@myapp --ruby-version --create
 $ gem install rails
 $ gem install rails_apps_composer
+$ gem install rvm # (only needed if creating a project-specific rvm gemset)
 $ rails_apps_composer new . -r core
 </pre>
 


### PR DESCRIPTION
This keeps biting me when I come back to rails_apps_composer without having used it in a while. If you don't have the rvm gem installed and answer "yes" to creating a project-specific gemset, you get an error during the generation process saying "rvm" cannot be loaded.
