### PR TITLE
Add diagnostic error output when rvm gemset can't be changed.

### DIFF
--- a/recipes/extras.rb
+++ b/recipes/extras.rb
@@ -46,6 +46,18 @@ if prefs[:rvmrc]
       end
     begin
       RVM.gemset_use! app_name
+      current_gemset = RVM.gemset_name
+      if current_gemset != app_name
+        case
+        # TODO: Need to update this to check current directory from where `rails_apps_composer new` command is run, not directory of __FILE__ or new rails app
+        when File.exists?(File.join(Dir.pwd, '.rvmrc')) || File.exists?(File.join(Dir.pwd, '.ruby-gemset'))
+          raise "Run command from directory with no .rvmrc or .ruby-gemset file."
+        when defined? Bundler
+          raise "Run command without using Bundler."
+        else
+          raise "Make sure to run without using .rvmrc, .ruby-gemset, or Gemfile."
+        end
+      end
     rescue => e
       say_wizard "rvm failure: unable to use gemset #{app_name}, reason: #{e}"
       raise


### PR DESCRIPTION
This is from our discussion on #170. It's not ready to merge yet though. See the "TODO" in the extras recipe. I'm having issues with getting the path of where the `rails_apps_composer new` command is being run, in order to check for the presence of a .rvmrc or .ruby-gemset file in that directory.

The problem is using something like `Dir.pwd` from within the extras recipe runs it after the current directory has been changed to the new rails app's directory. And we don't want `File.dirname(__FILE__)`, since they're not necessarily running the command from the file's directory.

I need to add something like this early on before the working directory is changed to the rails app's directory:

``` ruby
@@current_directory = Dir.pwd
def self.current_directory
  @@current_directory
end
```

...so that we can access it later from the extras recipe. I was thinking of putting it in the RailsWizard::Diagnostics module or somewhere like that, but not sure if that's the best place. Also, the RailsWizard module doesn't seem to be defined within the recipes, I'm guessing from the recipes being run via the erb template or something.
