### PR TITLE
Fixed issue with mailers causing errors from trying to be sent before email credentials are setup.

### DIFF
--- a/recipes/email.rb
+++ b/recipes/email.rb
@@ -11,7 +11,7 @@ after_bundler do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.raise_delivery_errors = true
   # Send email in development mode.
-  config.action_mailer.perform_deliveries = true
+  config.action_mailer.perform_deliveries = false
 TEXT
       prod_email_text = <<-TEXT
   # ActionMailer Config


### PR DESCRIPTION
I was having issues with using any of the mail services with devise. What was happening was that, if you select anything other than 'none' for email, the email recipe was turning on `action_mailer.perform_deliveries` in development. But then it was also setting up the email credentials with placeholder text, which of course will be invalid when trying to connect with the selected email service.

Normally this would be fine, because you could just update the credentials manually before trying to do anything with the app that would send emails.

However, devise creates a default admin user in the db/seeds.rb file, so when the `after_bundler` block runs `rake db:seed`, it creates a user, which then tries to send an email notification to the user and causes an error.

I was going to make it false only if devise was selected in the preferences. But then I was thinking, it's not generally good practice to have email delivery turned on by default in development. It could cause the developer to accidentally start sending email notifications to real people if they are entering real email addresses in their development environment (which is technically fine if emails aren't getting sent out). And they very well might not know deliveries are turned on, as it's the rails_apps_composer gem that's automatically doing that.

So I figured it may be better to turn it off in development by default and require the developer to turn it on if they'd like. And as a bonus, it fixes the devise seed error mentioned above.
