### PR TITLE
Clean up display of recipes and preferences in README.

### DIFF
--- a/recipes/readme.rb
+++ b/recipes/readme.rb
@@ -21,10 +21,12 @@ after_everything do
   # Diagnostics
   gsub_file "README.textile", /recipes that are known/, "recipes that are NOT known" if diagnostics[:recipes] == 'fail'
   gsub_file "README.textile", /preferences that are known/, "preferences that are NOT known" if diagnostics[:prefs] == 'fail'
-  gsub_file "README.textile", /RECIPES/, recipes.sort.inspect
-  gsub_file "README.textile", /PREFERENCES/, prefs.inspect
-  gsub_file "README", /RECIPES/, recipes.sort.inspect
-  gsub_file "README", /PREFERENCES/, prefs.inspect
+  print_recipes = recipes.sort.map { |r| "\n* #{r}" }.join('')
+  print_preferences = prefs.map { |k, v| "\n* #{k}: #{v}" }.join('')
+  gsub_file "README.textile", /RECIPES/, print_recipes
+  gsub_file "README.textile", /PREFERENCES/, print_preferences
+  gsub_file "README", /RECIPES/, print_recipes
+  gsub_file "README", /PREFERENCES/, print_preferences
 
   # Ruby on Rails
   gsub_file "README.textile", /\* Ruby/, "* Ruby version #{RUBY_VERSION}"


### PR DESCRIPTION
We always have to reformat the readme files because it currently spits out something like:

```
Recipes:
["admin", "apps4", "controllers", "core", "email", "email_dev", "extras", "frontend", "gems", "git", "init", "models", "prelaunch", "railsapps", "readme", "routes", "saas", "setup", "testing", "views"]

Preferences:
{:git=>true, :apps4=>"none", :dev_webserver=>"puma", :prod_webserver=>"puma", :database=>"postgresql", :templates=>"haml", :unit_test=>"rspec", :integration=>"rspec-capybara", :continuous_testing=>"none", :fixtures=>"factory_girl", :frontend=>"foundation5", :email=>"sendgrid", :authentication=>"devise", :devise_modules=>"confirmable", :authorization=>"none", :form_builder=>"simple_form", :starter_app=>"home_app", :rvmrc=>true, :quiet_assets=>true, :local_env_file=>"foreman", :better_errors=>true, :markdown_readme=>true, :admin=>"activeadmin", :mailcatcher=>true, :mail_view=>true}
```

With this patch, it instead spits out this:

```
Recipes:

* admin
* apps4
* controllers
* core
* email
* email_dev
* extras
* frontend
* gems
* git
* init
* models
* prelaunch
* railsapps
* readme
* routes
* saas
* setup
* testing
* views

Preferences:

* git: true
* apps4: none
* dev_webserver: puma
* prod_webserver: puma
* database: postgresql
* templates: haml
* unit_test: rspec
* integration: rspec-capybara
* continuous_testing: none
* fixtures: factory_girl
* frontend: foundation5
* email: sendgrid
* authentication: devise
* devise_modules: confirmable
* authorization: none
* form_builder: simple_form
* starter_app: home_app
* rvmrc: true
* quiet_assets: true
* local_env_file: foreman
* better_errors: true
* markdown_readme: true
* admin: activeadmin
* mailcatcher: true
* mail_view: true
```

I'll submit a separate pull request which updates the readme recipe to output markdown by default instead of textile, as discussed in #274.
