### PR TITLE
Fixed gemfile format for admin and email_dev recipes.

### DIFF
--- a/recipes/admin.rb
+++ b/recipes/admin.rb
@@ -10,12 +10,12 @@ end
 
 if prefer :admin, 'activeadmin'
   if rails_4?
-    gem 'activeadmin', github: 'gregbell/active_admin'
+    add_gem 'activeadmin', github: 'gregbell/active_admin'
   else
-    gem 'activeadmin'
+    add_gem 'activeadmin'
   end
 end
-gem 'rails_admin' if prefer :admin, 'rails_admin'
+add_gem 'rails_admin' if prefer :admin, 'rails_admin'
 
 after_bundler do
   if prefer :admin, 'activeadmin'

--- a/recipes/email_dev.rb
+++ b/recipes/email_dev.rb
@@ -6,12 +6,12 @@ prefs[:mail_view] = true if config['mail_view']
 
 if prefs[:mailcatcher]
   if rails_4?
-    gem 'mailcatcher', github: 'sj26/mailcatcher', group: :development
+    add_gem 'mailcatcher', github: 'sj26/mailcatcher', group: :development
   else
-    gem 'mailcatcher', group: :development
+    add_gem 'mailcatcher', group: :development
   end
 end
-gem 'mail_view', group: :development if prefs[:mail_view]
+add_gem 'mail_view', group: :development if prefs[:mail_view]
 
 after_bundler do
   if prefs[:mailcatcher]


### PR DESCRIPTION
I didn't realize there was a difference between the `gem` and `add_gem` helpers. Changed to fix the formatting of the admin and email_dev recipe gems in the Gemfile.

Should probably also update the example recipe in [the "Recipe Structure" section of the wiki](https://github.com/RailsApps/rails_apps_composer/wiki/tutorial-rails-apps-composer#wiki-anatomy-of-a-recipe) to use the `add_gem` helper.
