### PR TITLE
Update email ports from 25 to 587

### DIFF
--- a/recipes/email.rb
+++ b/recipes/email.rb
@@ -82,7 +82,7 @@ TEXT
 \n
   config.action_mailer.smtp_settings = {
     address: "smtp.sendgrid.net",
-    port: 25,
+    port: 587,
     domain: ENV["DOMAIN_NAME"],
     authentication: "plain",
     user_name: ENV["SENDGRID_USERNAME"],
@@ -98,7 +98,7 @@ TEXT
   \n
     config.action_mailer.smtp_settings = {
       :address   => "smtp.mandrillapp.com",
-      :port      => 25,
+      :port      => 587,
       :user_name => ENV["MANDRILL_USERNAME"],
       :password  => ENV["MANDRILL_APIKEY"]
     }


### PR DESCRIPTION
With Mandrill, I've run into the same issue as the OP in http://stackoverflow.com/questions/11356541/cant-get-mandrill-to-send-emails-from-rails-app so I suggest changing the default SMTP port from **25** to **587**. 

I've also found this regarding [Sendgrid's SMTP ports](http://sendgrid.com/docs/User_Guide/smtp_ports.html)
