### PR TITLE
domain_name required by devise even when none is selected for "EMAIL"

### DIFF
--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -38,10 +38,10 @@ after_everything do
   foreman_cancan = "ROLES=[admin, user, VIP]\n\n"
   figaro_cancan = foreman_cancan.gsub('=', ': ')
   ## EMAIL
+  inject_into_file 'config/secrets.yml', "\n" + "  domain_name: example.com", :after => "development:" if rails_4_1?
+  inject_into_file 'config/secrets.yml', "\n" + "  domain_name: <%= ENV[\"DOMAIN_NAME\"] %>", :after => "production:" if rails_4_1?
+  inject_into_file 'config/secrets.yml', "\n" + secrets_email, :after => "development:" if rails_4_1?
   unless prefer :email, 'none'
-    inject_into_file 'config/secrets.yml', "\n" + "  domain_name: example.com", :after => "development:" if rails_4_1?
-    inject_into_file 'config/secrets.yml', "\n" + "  domain_name: <%= ENV[\"DOMAIN_NAME\"] %>", :after => "production:" if rails_4_1?
-    inject_into_file 'config/secrets.yml', "\n" + secrets_email, :after => "development:" if rails_4_1?
     ### 'inject_into_file' doesn't let us inject the same text twice unless we append the extra space, why?
     inject_into_file 'config/secrets.yml', "\n" + secrets_email + " ", :after => "production:" if rails_4_1?
     append_file '.env', foreman_email if prefer :local_env_file, 'foreman'


### PR DESCRIPTION
Fixes 'TypeError: no implicit conversion of nil into String' when db:migrate if none is selected for "EMAIL" and devise is selected.
