### PR TITLE
ActiveAdmin support for Rails 4/4.1 requires github specification

### DIFF
--- a/recipes/admin.rb
+++ b/recipes/admin.rb
@@ -9,9 +9,10 @@ case config['admin']
 end
 
 if prefer :admin, 'activeadmin'
-  add_gem 'activeadmin'
+  add_gem 'activeadmin', github: 'gregbell/active_admin'
+elsif prefer :admin, 'rails_admin'
+  add_gem 'rails_admin'
 end
-add_gem 'rails_admin' if prefer :admin, 'rails_admin'
 
 stage_two do
   say_wizard "recipe stage two"


### PR DESCRIPTION
Plain gem 'activeadmin' was failing under Rails 4/4.1 and https://github.com/gregbell/active_admin doc indicates it is still proper to use:

```
gem 'activeadmin', github: 'gregbell/active_admin'
```

I've added that to the recipe and specs and local gem testing now works when trying to build sample apps with ActiveAdmin.
