### PR TITLE
fix for Procfile create/update: newline added to the end of content

### DIFF
--- a/recipes/email_dev.rb
+++ b/recipes/email_dev.rb
@@ -32,7 +32,7 @@ end
 RUBY
     end
     if prefer(:local_env_file, 'foreman') && File.exists?('Procfile.dev')
-      append_file 'Procfile.dev', 'mail: mailcatcher --foreground'
+      append_file 'Procfile.dev', "mail: mailcatcher --foreground\n"
     end
     ### GIT
     git :add => '-A' if prefer :git, true

--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -250,15 +250,15 @@ FILE
 
 FILE
     end
-    create_file 'Procfile', 'web: bundle exec rails server -p $PORT' if prefer :prod_webserver, 'thin'
-    create_file 'Procfile', 'web: bundle exec unicorn -p $PORT' if prefer :prod_webserver, 'unicorn'
-    create_file 'Procfile', 'web: bundle exec puma -p $PORT' if prefer :prod_webserver, 'puma'
-    create_file 'Procfile', 'web: bundle exec passenger start -p $PORT' if prefer :prod_webserver, 'passenger_standalone'
+    create_file 'Procfile', "web: bundle exec rails server -p $PORT\n" if prefer :prod_webserver, 'thin'
+    create_file 'Procfile', "web: bundle exec unicorn -p $PORT\n" if prefer :prod_webserver, 'unicorn'
+    create_file 'Procfile', "web: bundle exec puma -p $PORT\n" if prefer :prod_webserver, 'puma'
+    create_file 'Procfile', "web: bundle exec passenger start -p $PORT\n" if prefer :prod_webserver, 'passenger_standalone'
     if (prefs[:dev_webserver] != prefs[:prod_webserver])
-      create_file 'Procfile.dev', 'web: bundle exec rails server -p $PORT' if prefer :dev_webserver, 'thin'
-      create_file 'Procfile.dev', 'web: bundle exec unicorn -p $PORT' if prefer :dev_webserver, 'unicorn'
-      create_file 'Procfile.dev', 'web: bundle exec puma -p $PORT' if prefer :dev_webserver, 'puma'
-      create_file 'Procfile.dev', 'web: bundle exec passenger start -p $PORT' if prefer :dev_webserver, 'passenger_standalone'
+      create_file 'Procfile.dev', "web: bundle exec rails server -p $PORT\n" if prefer :dev_webserver, 'thin'
+      create_file 'Procfile.dev', "web: bundle exec unicorn -p $PORT\n" if prefer :dev_webserver, 'unicorn'
+      create_file 'Procfile.dev', "web: bundle exec puma -p $PORT\n" if prefer :dev_webserver, 'puma'
+      create_file 'Procfile.dev', "web: bundle exec passenger start -p $PORT\n" if prefer :dev_webserver, 'passenger_standalone'
     end
   end
   ## Git


### PR DESCRIPTION
This fix was made for a tiny bug fix.
For example, we have following defaults:

```
recipes:
- gems
- email_dev
prefs:
  :dev_webserver: thin
  :prod_webserver: puma
  :mailcatcher: true
```

In this case we'll have following `Procfile.dev`:

```
web: bundle exec rails server -p $PORTmail: mailcatcher --foreground
```

So we just need to add `\n` to the end of each `Procfile` line.
