### PR TITLE
Substitue backtick with a single quote

### DIFF
--- a/recipes/readme.rb
+++ b/recipes/readme.rb
@@ -126,7 +126,7 @@ Need help? Ask on Stack Overflow with the tag 'railsapps.'
 
 Your application contains diagnostics in the README file. Please provide a copy of the README file when reporting any issues.
 
-If the application doesn’t work as expected, please [report an issue](https://github.com/RailsApps/rails_apps_composer/issues)
+If the application doesn't work as expected, please [report an issue](https://github.com/RailsApps/rails_apps_composer/issues)
 and include the diagnostics.
 
 Ruby on Rails


### PR DESCRIPTION
Otherwise if I tried:

``` bash
rails_apps_composer new . -r core
```

 I would get:

``` bash
.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rails_apps_composer-3.0.28/lib/rails_wizard/recipe.rb:30:in `split': invalid byte sequence in US-ASCII (ArgumentError)
```
