### PR TITLE
Use add_gems to consolidate gems from the same group

### DIFF
--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -129,7 +129,7 @@ add_gem 'simple_form' if prefer :form_builder, 'simple_form'
 
 ## Gems from a defaults file or added interactively
 gems.each do |g|
-  gem(*g)
+  add_gem(*g)
 end
 
 ## Git


### PR DESCRIPTION
Say I have these gems defined in my defaults file:

    gems:
      - 
        - bullet
        - :group: :development
      -
        - lol_dba
        - :group: :development
      -
        - rails-dev-boost
        - :group: :development

The gems added into the Gemfile by `gem` will appear outside of the `development` group block like this in the Gemfile:

    gem 'bullet', group: :development
    gem 'lol_dba', group: :development
    gem 'rails-dev-boost', group: :development

To fix this, we should use `add_gem` instead. :smile: 