### PR TITLE
Use ~> on activeadmin gem version

### DIFF
--- a/recipes/admin.rb
+++ b/recipes/admin.rb
@@ -9,7 +9,7 @@ case config['admin']
 end
 
 if prefer :admin, 'activeadmin'
-  add_gem 'activeadmin', github: 'gregbell/active_admin'
+  add_gem 'activeadmin', '~> 1.0.0.pre2'
 elsif prefer :admin, 'rails_admin'
   add_gem 'rails_admin'
 end


### PR DESCRIPTION
Activeadmin finally has version and will soon reach 1.0.0.

Pessimistic Version Constraint:
http://guides.rubygems.org/patterns/#pessimistic_version_constraint