### PR TITLE
Changed call to confirm! to a call to confirm in recipes/init.rb to fix the Devise confirmable module

### DIFF
--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -112,7 +112,7 @@ FILE
   end
   ## DEVISE-CONFIRMABLE
   if (prefer :devise_modules, 'confirmable') || (prefer :devise_modules, 'invitable')
-    inject_into_file 'app/services/create_admin_service.rb', "        user.confirm!\n", :after => "user.password_confirmation = Rails.application.secrets.admin_password\n"
+    inject_into_file 'app/services/create_admin_service.rb', "        user.confirm\n", :after => "user.password_confirmation = Rails.application.secrets.admin_password\n"
   end
   ## DEVISE-INVITABLE
   if prefer :devise_modules, 'invitable'


### PR DESCRIPTION
This should fix the issue https://github.com/RailsApps/rails-devise-roles/issues/11 ("create_admin_service.rb causes rake to fail because the confirm! method was removed from the Devise gem").

Please refer to the [changelog in master](https://github.com/plataformatec/devise/blob/master/CHANGELOG.md) of the Devise gem.