### PR TITLE
Fix guard-rspec `require: false` in gemfile

### DIFF
--- a/recipes/gems.rb
+++ b/recipes/gems.rb
@@ -68,7 +68,7 @@ if prefer :tests, 'rspec'
   if prefer :continuous_testing, 'guard'
     add_gem 'guard-bundler', :group => :development
     add_gem 'guard-rails', :group => :development
-    add_gem 'guard-rspec', :group => :development
+    add_gem 'guard-rspec', :group => :development, :require => false
     add_gem 'rb-inotify', :group => :development, :require => false
     add_gem 'rb-fsevent', :group => :development, :require => false
     add_gem 'rb-fchange', :group => :development, :require => false


### PR DESCRIPTION
Installs guard-rspec with :require => false which follows the instructions at https://github.com/guard/guard-rspec#install

This eliminates the error irb: warn: can't alias context from irb_context. on rails c