### PR TITLE
Fix .gitignore master.key bug.

### DIFF
--- a/recipes/git.rb
+++ b/recipes/git.rb
@@ -2,20 +2,17 @@
 # https://github.com/RailsApps/rails_apps_composer/blob/master/recipes/git.rb
 
 ## Git
-say_wizard "initialize git"
 prefs[:git] = true unless prefs.has_key? :git
 if prefer :git, true
-  copy_from 'https://raw.github.com/RailsApps/rails-composer/master/files/gitignore.txt', '.gitignore'
-  git :init
+  if !File.directory?('.git')
+    say_wizard "initialize git"
+    git :init
+  end
+  if !File.file?('.gitignore')
+    copy_from 'https://raw.github.com/RailsApps/rails-composer/master/files/gitignore.txt', '.gitignore'
+  end
   git :add => '-A'
   git :commit => '-qm "rails_apps_composer: initial commit"'
-else
-  stage_three do
-    say_wizard "recipe stage three"
-    say_wizard "removing .gitignore and .gitkeep files"
-    git_files = Dir[File.join('**','.gitkeep')] + Dir[File.join('**','.gitignore')]
-    File.unlink git_files
-  end
 end
 
 __END__


### PR DESCRIPTION
Rails 5.2 uses config/master.key to encrypt credentials.

https://medium.com/@wintermeyer/goodbye-secrets-welcome-credentials-f4709d9f4698

It is important to keep config/master.key out of git.

By default, Rails 5.2 initializes git and adds a .gitignore file which ignores the master.key file.

The git recipe currently unconditionally reinitalizes git even if has already been initialized by Rails.

The git recipe currently unconditionally replaces .gitignore with an outdated version. This results in the master.key file being committed into git. Once it has been committed it is difficult to entirely remove from the git history. A naive "git rm config/master.key" will leave the file in the git history, opening a security hole.

This PR fixes the git recipe to not reinitialize git if .git exists and to not clobber the Rails .gitignore file if it has already been set up.

This PR also refrains from removing all .gitignore and .gitkeep files. That doesn't seem useful or safe.

To reproduce the bug:

$ rails_apps_composer new git-bug-test -r git
$ cd git-bug-test
$ git ls-files config/master.key
config/master.key # Bug: master.key is checked into git.

Test the fix:

$ git clone git@github.com:jgorman/rails_apps_composer_pr.git
$ cd rails_apps_composer_pr
$ git co git-bug
$ rake reinstall

$ rails_apps_composer new git-bug-fixed -r git
$ cd git-bug-fixed
$ git ls-files config/master.key
$ # Fixed: master.key is not checked into git.

Test that git still gets initialized when Rails doesn't do it.

$ echo '--skip-git' > ~/.railsrc
$ rails_apps_composer new git-bug-old-rails -r git
$ cd git-bug-old-rails
$ git ls-files .gitignore
.gitignore # Older Rails: git and .gitignore are still set up.